### PR TITLE
Broker replay mechanism

### DIFF
--- a/bin/pastis-benchmark
+++ b/bin/pastis-benchmark
@@ -164,10 +164,11 @@ def showmap(bins: str):
 @click.option('--stream', type=bool, is_flag=True, default=False, help="Stream input and coverage info in the given file", show_default=True)
 @click.option('--replay-threads', type=int, default=4, help="number of threads to use for input replay", show_default=True)
 @click.option('--proxy', type=str, default="", help="Run the broker as a proxy to another broker")
+@click.argument('pargvs', nargs=-1)
 def run(workspace: str, bins: str, seeds: str, mode: str, injloc: str, aflpp: bool, hfuzz: bool, triton: bool,
         debug: bool, timeout: Optional[int], port: int, hfuzz_path: str, hfuzz_threads: int, spawn: bool,
         allow_remote: bool, probe: Tuple[str], skip_cpufreq: bool,  mem_threshold: int, start_quorum: int,  proxy: str,
-        filter_inputs: bool, stream: bool, replay_threads: int):
+        filter_inputs: bool, stream: bool, replay_threads: int, pargs: Tuple[str]):
 
     configure_logging(logging.DEBUG if debug else logging.INFO, "%(asctime)s %(name)s [%(levelname)s] %(message)s")
 
@@ -177,7 +178,7 @@ def run(workspace: str, bins: str, seeds: str, mode: str, injloc: str, aflpp: bo
                           CheckMode.CHECK_ALL,
                           SeedInjectLoc[injloc],
                           None,
-                          [],
+                          list(pargs),
                           mem_threshold,
                           start_quorum,
                           filter_inputs,

--- a/bin/pastis-benchmark
+++ b/bin/pastis-benchmark
@@ -164,7 +164,7 @@ def showmap(bins: str):
 @click.option('--stream', type=bool, is_flag=True, default=False, help="Stream input and coverage info in the given file", show_default=True)
 @click.option('--replay-threads', type=int, default=4, help="number of threads to use for input replay", show_default=True)
 @click.option('--proxy', type=str, default="", help="Run the broker as a proxy to another broker")
-@click.argument('pargvs', nargs=-1)
+@click.argument('pargs', nargs=-1)
 def run(workspace: str, bins: str, seeds: str, mode: str, injloc: str, aflpp: bool, hfuzz: bool, triton: bool,
         debug: bool, timeout: Optional[int], port: int, hfuzz_path: str, hfuzz_threads: int, spawn: bool,
         allow_remote: bool, probe: Tuple[str], skip_cpufreq: bool,  mem_threshold: int, start_quorum: int,  proxy: str,

--- a/bin/pastis-benchmark
+++ b/bin/pastis-benchmark
@@ -158,15 +158,31 @@ def showmap(bins: str):
 @click.option("--allow-remote", type=bool, is_flag=True, default=False, help="Enable remote connection")
 @click.option('--probe', type=str, help="Probe to load as a python module (should contain a ProbeInterface)", multiple=True)
 @click.option('--skip-cpufreq', is_flag=True, type=bool, default=False, help="Skip CPU frequency scaling check")
+@click.option('--mem-threshold', type=int, default=85, help="RAM consumption limit", show_default=True)
 @click.option('--start-quorum', type=int, default=0, help="Number of client connection to receive before triggering startup", show_default=True)
+@click.option('--filter-inputs', type=bool, is_flag=True, default=False, help="Filter inputs that do not generate coverage", show_default=True)
+@click.option('--stream', type=bool, is_flag=True, default=False, help="Stream input and coverage info in the given file", show_default=True)
+@click.option('--replay-threads', type=int, default=4, help="number of threads to use for input replay", show_default=True)
 @click.option('--proxy', type=str, default="", help="Run the broker as a proxy to another broker")
 def run(workspace: str, bins: str, seeds: str, mode: str, injloc: str, aflpp: bool, hfuzz: bool, triton: bool,
         debug: bool, timeout: Optional[int], port: int, hfuzz_path: str, hfuzz_threads: int, spawn: bool,
-        allow_remote: bool, probe: Tuple[str], skip_cpufreq: bool, start_quorum: int, proxy: str):
+        allow_remote: bool, probe: Tuple[str], skip_cpufreq: bool,  mem_threshold: int, start_quorum: int,  proxy: str,
+        filter_inputs: bool, stream: bool, replay_threads: int):
 
     configure_logging(logging.DEBUG if debug else logging.INFO, "%(asctime)s %(name)s [%(levelname)s] %(message)s")
 
-    broker = PastisBroker(workspace, bins, BrokingMode[mode], CheckMode.CHECK_ALL, SeedInjectLoc[injloc], None, [], start_quorum=start_quorum)
+    broker = PastisBroker(workspace,
+                          bins,
+                          BrokingMode[mode],
+                          CheckMode.CHECK_ALL,
+                          SeedInjectLoc[injloc],
+                          None,
+                          [],
+                          mem_threshold,
+                          start_quorum,
+                          filter_inputs,
+                          stream,
+                          replay_threads)
 
     if proxy:  # proxy format should be:  IP:port@py_module
         url, py_module = proxy.split("@")

--- a/bin/pastis-benchmark
+++ b/bin/pastis-benchmark
@@ -163,7 +163,7 @@ def showmap(bins: str):
 @click.option('--filter-inputs', type=bool, is_flag=True, default=False, help="Filter inputs that do not generate coverage", show_default=True)
 @click.option('--stream', type=bool, is_flag=True, default=False, help="Stream input and coverage info in the given file", show_default=True)
 @click.option('--replay-threads', type=int, default=4, help="number of threads to use for input replay", show_default=True)
-@click.option('--proxy', type=str, default="", help="Run the broker as a proxy to another broker")
+@click.option('--proxy', type=str, default="", help="Run the broker as a proxy to another broker: pymodule@ip:port")
 @click.argument('pargs', nargs=-1)
 def run(workspace: str, bins: str, seeds: str, mode: str, injloc: str, aflpp: bool, hfuzz: bool, triton: bool,
         debug: bool, timeout: Optional[int], port: int, hfuzz_path: str, hfuzz_threads: int, spawn: bool,
@@ -186,9 +186,13 @@ def run(workspace: str, bins: str, seeds: str, mode: str, injloc: str, aflpp: bo
                           replay_threads)
 
     if proxy:  # proxy format should be:  IP:port@py_module
-        url, py_module = proxy.split("@")
-        proxy_ip, proxy_port = url.split(":")
-        broker.set_proxy(proxy_ip, int(proxy_port), py_module)
+        try:
+            py_module, url = proxy.split("@")
+            proxy_ip, proxy_port = url.split(":")
+            broker.set_proxy(proxy_ip, int(proxy_port), py_module)
+        except ValueError:
+            logging.error(f"Cannot parse proxy: {proxy}, format need to be: py_module@ip:port")
+            return
 
     # Add all given seeds as initial seed
     if seeds is None:

--- a/bin/pastis-broker
+++ b/bin/pastis-broker
@@ -54,10 +54,14 @@ def iterate_file(file):
 @click.option('-p', '--port', type=int, default=5555, help="Port to bind to", multiple=False, show_default=True)
 @click.option('--mem-threshold', type=int, default=85, help="RAM consumption limit", show_default=True)
 @click.option('--start-quorum', type=int, default=0, help="Number of client connection to receive before triggering startup", show_default=True)
+@click.option('--filter-inputs', type=bool, is_flag=True, default=False, help="Filter inputs that do not generate coverage", show_default=True)
+@click.option('--stream', type=bool, is_flag=True, default=False, help="Stream input and coverage info in the given file", show_default=True)
+@click.option('--replay-threads', type=int, default=4, help="number of threads to use for input replay", show_default=True)
 @click.argument('pargvs', nargs=-1)
 def main(workspace: str, sast_report: Optional[str], bins: str, mode: str, chkmode: str, injloc: str, engine: Tuple[str],
          tt_config: Optional[str], hf_config: Optional[str], seed: Tuple[str], timeout: Optional[int],
-         port: Optional[int], pargvs: Tuple[str], mem_threshold: int, start_quorum: int):
+         port: Optional[int], pargvs: Tuple[str], mem_threshold: int, start_quorum: int, filter_inputs: bool,
+         stream: bool, replay_threads: int):
     global broker
     # Instanciate the broker
 
@@ -66,7 +70,18 @@ def main(workspace: str, sast_report: Optional[str], bins: str, mode: str, chkmo
         logging.error(f"Check mode {chkmode.name} requires a SAST report (use -r) to provide it")
         sys.exit(1)
 
-    broker = PastisBroker(workspace, bins, BrokingMode[mode], chkmode, SeedInjectLoc[injloc], sast_report, list(pargvs), mem_threshold, start_quorum)
+    broker = PastisBroker(workspace,
+                          bins,
+                          BrokingMode[mode],
+                          chkmode,
+                          SeedInjectLoc[injloc],
+                          sast_report,
+                          list(pargvs),
+                          mem_threshold,
+                          start_quorum,
+                          filter_inputs,
+                          stream,
+                          replay_threads)
 
     # Preload all Fuzzing engine if needed
     for eng in engine:

--- a/engines/pastis-aflpp/pastisaflpp/driver.py
+++ b/engines/pastis-aflpp/pastisaflpp/driver.py
@@ -78,7 +78,7 @@ class AFLPPDriver:
 
         logging.info(f"Start process (injectloc: {seed_inj.name})")
         self.aflpp.start(str(package.executable_path.absolute()),
-                         " ".join(argv),
+                         argv,
                          self.workspace,
                          exmode,
                          fuzzmode,

--- a/engines/pastis-honggfuzz/pastishf/driver.py
+++ b/engines/pastis-honggfuzz/pastishf/driver.py
@@ -78,8 +78,8 @@ class HonggfuzzDriver:
         self.workspace.start()  # Start looking at directories
 
         logging.info("Start process")
-        if not self.honggfuzz.start(self.__package.executable_path.absolute(),
-                             " ".join(argv),
+        if not self.honggfuzz.start(str(self.__package.executable_path.absolute()),
+                             argv,
                              self.workspace,
                              exmode,
                              fuzzmode,

--- a/engines/pastis-honggfuzz/pastishf/driver.py
+++ b/engines/pastis-honggfuzz/pastishf/driver.py
@@ -86,7 +86,7 @@ class HonggfuzzDriver:
                              seed_inj == SeedInjectLoc.STDIN,
                              engine_args,
                              str(package.dictionary.absolute()) if package.dictionary else None):
-            self._agent.send_log(LogLevel.ERROR, "Cannot start target, HFQBDIPRELAOD not found")
+            self._agent.send_log(LogLevel.ERROR, "Cannot start target")
         self._started = True
 
         # Start the replay worker (note that the queue might already have started to be filled by agent thread)

--- a/engines/pastis-triton/bin/pastis-triton
+++ b/engines/pastis-triton/bin/pastis-triton
@@ -58,8 +58,9 @@ def cli():
 @cli.command()
 @click.option('-h', '--host', type=str, default='localhost', help='Host to connect to')
 @click.option('-p', '--port', type=int, default=5555, help='Port to connect to')
+@click.option('--debug', type=bool,  is_flag=True, show_default=True, default=False, help='Enable debug logs')
 @click.option('--probe', type=str, help="Probe to load as a python module (should contain a ProbeInterface)", multiple=True)
-def online(host: str, port: int, probe: Tuple[str]):
+def online(host: str, port: int, debug: bool, probe: Tuple[str]):
     """
     This is the online mode of the pastis-triton exploration. With this mode,
     the client (pastis-triton) will try to connect to the broker. Then, the broker
@@ -67,9 +68,11 @@ def online(host: str, port: int, probe: Tuple[str]):
 
     :param host: The remote host to connect
     :param port: The remote host's port to connect
+    :param debug: Configure debugging logs
+    :param probe: Probes to enable (Python modules imported with importlib)
     """
 
-    configure_logs(logging.INFO)
+    configure_logs(logging.DEBUG if debug else logging.INFO)
 
     # Create the network agent and connect to the broker
     agent = ClientAgent()

--- a/engines/pastis-triton/pastisdse/pastisdse.py
+++ b/engines/pastis-triton/pastisdse/pastisdse.py
@@ -566,7 +566,7 @@ class PastisDSE(object):
                     self.dse.add_input_seed(seed)
                 else:
                     # Check whether the seed improves the current coverage.
-                    if self.dse.coverage.improves_coverage(coverage):
+                    if self.dse.coverage.improve_coverage(coverage):
                         logging.info(f"seed added {seed.hash} [{typ.name}] (coverage merged)")
                         self.seeds_merged += 1
                         self.dse.coverage.merge(coverage)

--- a/engines/pastis-triton/pastisdse/pastisdse.py
+++ b/engines/pastis-triton/pastisdse/pastisdse.py
@@ -314,10 +314,10 @@ class PastisDSE(object):
             self.config = Config.from_json(engine_args)
         else:
             self.config = Config()  # Empty configuration
-
-        # Override config argv if provided
-        if argv:
-            self.config.program_argv = argv
+            # Use argv ONLY if no configuration provided
+            self.config.program_argv = [f"./{fname}"]
+            if argv:
+                self.config.program_argv.extend(argv) # Preprend the binary to argv
 
         """
         Actions taken depending on seed format & co:

--- a/engines/pastis-triton/pastisdse/pastisdse.py
+++ b/engines/pastis-triton/pastisdse/pastisdse.py
@@ -534,9 +534,6 @@ class PastisDSE(object):
                         logging.error(f"seed injection {self._seedloc.name} but can't find 'input_file' on program argv")
                         return
 
-                # set the longjmp addr if defined
-                if hasattr(self.program, "longjmp_addr"):
-                    os.environ["TT_LONGJMP_ADDR"] = str(self.program.longjmp_addr)
                 try:
                     # Run the seed and determine whether it improves our current coverage.
                     t0 = time.time()

--- a/libpastis/proto/message.proto
+++ b/libpastis/proto/message.proto
@@ -67,7 +67,7 @@ message StartMsg {
     string coverage_mode   = 8;       // coverage strategy for Triton (ignored by Triton)
     SeedInjectLoc seed_location  = 9;
     string engine_args           = 10; // Serialized JSON of engine parameters
-    repeated string program_argv = 11;
+    repeated string program_argv = 11;  // Arguments (without program name (argv[0]))
 }
 
 message StopMsg {

--- a/pastisbenchmark/replayer.py
+++ b/pastisbenchmark/replayer.py
@@ -43,24 +43,9 @@ class Replayer(object):
         # initiatialize directories
         self._init_directories()
 
-        # set longjmp ENV var if applicable
-        self._set_longjump_plt()
-
     def _init_directories(self):
         if not self.corpus_replay_dir.exists():
             self.corpus_replay_dir.mkdir()
-
-    def _set_longjump_plt(self):
-        try:
-            proc = subprocess.Popen(['objdump', '-D', self.program.absolute()], stdout=subprocess.PIPE)
-            out, err = proc.communicate()
-            for line in out.split(b"\n"):
-                if b"<longjmp@plt>:" in line:
-                    addr = line.split()[0]
-                    logging.info(f"lonjmp address found at: {addr}")
-                    os.environ["TT_LONGJMP_ADDR"] = str(int(addr, 16))
-        except:
-            return 0
 
     @property
     def corpus_replay_dir(self) -> Path:

--- a/pastisbroker/coverage.py
+++ b/pastisbroker/coverage.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+import time
+import logging
+import tempfile
+import os
+import subprocess
+from typing import Generator
+from pathlib import Path
+import queue
+import csv
+from dataclasses import dataclass
+from threading import Thread
+from multiprocessing import Queue, Manager
+from multiprocessing.pool import Pool
+
+from libpastis.types import SeedType, SeedInjectLoc
+
+# tritondse imports
+from tritondse import GlobalCoverage, CoverageSingleRun, CoverageStrategy, BranchSolvingStrategy
+from tritondse.trace import QBDITrace, TraceException
+
+from pastisbroker.utils import Bcolors, mk_color
+
+
+@dataclass
+class ClientInput:
+    content: bytes          # Content of the input
+    log_time: str           # Time the log has been generated
+    recv_time: str          # Time the input has been received
+    elapsed: str            # Elapsed time since the begining
+    hash: str               # Input hash
+    path: str               # Input file path
+    seed_status: SeedType   # Status of the seed
+    fuzzer_id: bytes        # Fuzzer ID
+    fuzzer_name: str        # Fuzzer name
+    broker_status: str      # Status in: DUPLICATE, DROPPED, GRANTED
+    replay_status: str      # Status in: OK, TRACE_EXCEPTION, FAIL
+    replay_time: float      # Time taken for the replay
+    new_coverage: list[tuple[int, int]]  # New items covered
+
+
+class CoverageManager(object):
+
+    ARGV_PLACEHOLDER = "@@"
+    STRATEGY = CoverageStrategy.EDGE
+
+    def __init__(self, pool_size: int, filter: bool, program: str, args: list[str], inj_loc: SeedInjectLoc, stream_file: str = ""):
+        # Base info for replay
+        self.pool_size = pool_size
+        self.filter_enabled = filter
+        self.program = str(program)
+        self.args = args
+        self.inj_loc = inj_loc
+        self.longjmp_addr = self.calc_longjmp_addr(self.program)
+
+        # Coverage and messaging attributes
+        self._coverage = GlobalCoverage(self.STRATEGY, BranchSolvingStrategy.ALL_NOT_COVERED)
+        self._manager = Manager()
+        self.input_queue = self._manager.Queue()
+        self.cov_queue = self._manager.Queue()
+        self.granted_queue = self._manager.Queue()
+
+        # Pool of workers
+        self.pool = Pool(self.pool_size)
+        self._running = False
+        self.cov_worker = Thread(name="[coverage_worker]", target=self.coverage_worker)
+
+        # stats
+        self.seeds_accepted, self.seeds_submitted = 0, 0
+        self.cli_stats = {}
+
+        # Streaming
+        if stream_file:
+            self.stream_file = open(stream_file, "a")
+            self.csv = csv.writer(self.stream_file)
+        else:
+            self.stream_file, self.csv = None, None
+
+
+    def start(self) -> None:
+        """
+        Start all the workers
+        """
+        # First start the coverage worker
+        self._running = True
+        self.cov_worker.start()
+        logging.info("Starting coverage manager")
+
+        for work_id in range(self.pool_size):
+            self.pool.apply_async(self.worker, (self.input_queue, self.cov_queue, self.program, self.args, self.inj_loc, self.longjmp_addr))
+
+    def stop(self) -> None:
+        self._running = False
+        self.cov_worker.join()
+        self.pool.terminate()
+
+    @staticmethod
+    def calc_longjmp_addr(program) -> int:
+        # TODO find a better way to do this
+        # There is no generic way but since the plt layout is known we could do
+        # https://github.com/lief-project/LIEF/issues/762
+        try:
+            proc1 = subprocess.Popen(['objdump', '-D', f'{program}'], stdout=subprocess.PIPE)
+            proc2 = subprocess.Popen(['grep', '<longjmp@plt>:'], stdin=proc1.stdout,
+                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+            proc1.stdout.close() # Allow proc1 to receive a SIGPIPE if proc2 exits.
+            out, err = proc2.communicate()
+            return int(out.split()[0], 16)
+        except:
+            return 0
+
+    def push_input(self, cli_input: ClientInput) -> None:
+        """ Push the input in the """
+        cli_input.log_time = time.strftime("%Y-%m-%d_%H:%M:%S", time.localtime())
+        # logging.info(f"push input {str(cli_input)[:50]}")
+
+        # Update stats
+        self.seeds_submitted += 1
+        if cli_input.fuzzer_id in self.cli_stats:
+            self.cli_stats[cli_input.fuzzer_id][0] += 1
+        else:
+            self.cli_stats[cli_input.fuzzer_id] = [1, 0]
+
+        self.input_queue.put(cli_input)
+
+    def iter_granted_inputs(self) -> Generator[ClientInput, None, None]:
+        try:
+            while True:
+                yield self.granted_queue.get_nowait()
+        except queue.Empty:
+            pass
+
+    @staticmethod
+    def worker_sleep(q, n) -> None:
+        """
+        worker thread that unstack inputs and replay them.
+        """
+        time.sleep(n)
+        q.put_nowait(n)
+        return n
+
+    def add_item_coverage_stream(self, item: ClientInput) -> None:
+        if self.stream_file:  # Stream enabled
+            self.csv.writerow([
+                item.log_time,
+                item.recv_time,
+                item.elapsed,
+                item.hash,
+                item.path,
+                item.seed_status.name,
+                item.fuzzer_name,
+                item.broker_status,
+                item.replay_status,
+                f"{item.replay_time:.2f}",
+                item.new_coverage
+            ])
+            self.stream_file.flush()
+
+    def coverage_worker(self):
+        while self._running:
+            try:
+                item, cov_file = self.cov_queue.get(timeout=0.5)
+                # logging.info("Coverage worker fetch item")
+                new_items = []
+                try:
+                    coverage: CoverageSingleRun = QBDITrace.from_file(cov_file).coverage
+                    if self._coverage.improve_coverage(coverage):
+                        self.cli_stats[item.fuzzer_id][1] += 1  # input accepted
+                        self.seeds_accepted += 1
+
+                        # Get newly covered items (and put them in the stream queue
+
+                        new_items = coverage.difference(self._coverage)
+
+                        item.new_coverage = list(new_items)
+
+                        # logging.info(f"seed {item.hash}  ({item.fuzzer_name}) [replay:{}][status:{}] ({len(new_items)} new edges)")
+
+                        # Update the global coverage
+                        self._coverage.merge(coverage)
+
+                        if item.fuzzer_name != "INITIAL":  # if not initial corpus and granted
+                            self.granted_queue.put(item)
+
+                    else:
+                        item.broker_status = "DROPPED" if self.filter_enabled else "GRANTED"
+                        # logging.info(f"seed {item.hash} ({item.seed_status.name}) of {item.fuzzer_name} rejected (do not improve coverage)")
+
+                    # Remove the coverage file
+                    os.unlink(cov_file)
+                except FileNotFoundError:
+                    if item.seed_status == SeedType.INPUT:
+                        logging.warning(f"seed {item.hash}({item.seed_status}) can't load coverage file (maybe had crashed?)")
+                    else:
+                        logging.info(f"seed {item.hash}({item.seed_status}) cannot get coverage (normal..)")
+                    # Grant input
+                    self.seeds_accepted += 1
+                    self.granted_queue.put(item)
+
+                logging.info(f"seed {item.hash} ({item.fuzzer_name}) [replay:{self.mk_rpl_status(item.replay_status)}][status:{self.mk_broker_status(item.broker_status, bool(new_items))}] ({len(new_items)} new edges)")
+                # Regardless if it was a success or not log it
+                self.add_item_coverage_stream(item)
+            except queue.Empty:
+                pass
+            except KeyboardInterrupt:
+                self._running = False
+                logging.info("coverage worker stop")
+                break
+
+    @staticmethod
+    def mk_rpl_status(status: str) -> str:
+        if status == "SUCCESS":
+            return mk_color(status, Bcolors.OKGREEN)
+        else:
+            return mk_color(status, Bcolors.FAIL)
+
+
+    @staticmethod
+    def mk_broker_status(status: str, new_items: bool) -> str:
+        if status == "GRANTED":
+            return mk_color(status, Bcolors.OKGREEN if new_items else Bcolors.WARNING)
+        elif status == "DROPPED":
+            return mk_color(status, Bcolors.WARNING)
+        else:
+            return mk_color(status, Bcolors.FAIL)
+
+    @staticmethod
+    def worker(input_queue: Queue, cov_queue: Queue, program: str, argv: list[str], seed_inj: SeedInjectLoc, longjaddr: int) -> None:
+        """
+        worker thread that unstack inputs and replay them.
+        """
+        tmpfile = Path(tempfile.mktemp(suffix=f"{os.getpid()}.input"))
+        pid = os.getpid()
+        try:
+            while True:
+                item: ClientInput = input_queue.get()
+                # logging.debug(f"Worker {os.getpid()} fetch: {str(item)[:50]}")
+                # Write inputs in our tempfile
+                tmpfile.write_bytes(item.content)
+
+                # Create to coverage file
+                cov_file = tempfile.mktemp(f"_{item.hash}.cov")
+
+                # Adjust injection location before calling QBDITrace
+                cur_argv = argv[:]
+                if seed_inj == SeedInjectLoc.ARGV:  # Try to replace the placeholder with filename
+                    try:
+                        # Replace 'input_file' in argv with the temporary file name created
+                        idx = cur_argv.index(CoverageManager.ARGV_PLACEHOLDER)
+                        cur_argv[idx] = str(tmpfile)
+                    except ValueError as e:
+                        logging.error(f"seed injection {seed_inj.name} but can't find '@@' on program argv: {argv}: {e}")
+                        continue
+
+                # Set longjump addr if any
+                os.environ["TT_LONGJMP_ADDR"] = str(longjaddr)
+
+                try:
+                    # Run the seed
+                    t0 = time.time()
+                    if QBDITrace.run(CoverageManager.STRATEGY,
+                                     program,
+                                     cur_argv,  # argv[1:] if len(argv) > 1 else [],
+                                     output_path=str(cov_file),
+                                     stdin_file=str(tmpfile) if seed_inj == SeedInjectLoc.STDIN else None,
+                                     cwd=Path(program).parent,
+                                     timeout=60):
+                        item.replay_time = time.time() - t0
+                        item.replay_status = "SUCCESS"
+                        # logging.info(f"[worker-{pid}] replaying {item.hash} sucessful")
+                    else:
+                        item.replay_status = "FAIL_NO_COV"
+                        logging.warning("Cannot load the coverage file generated (maybe had crashed?)")
+                except TraceException:
+                    item.replay_status = "FAIL_TIMEOUT"
+                    logging.warning('Timeout hit, while trying to re-run the seed')
+
+                # Add it to the coverage queue (even if it failed
+                cov_queue.put((item, cov_file))
+        except KeyboardInterrupt:
+            pass
+            # logging.info(f"replay worker {os.getpid()}, stops (keyboard interrupt)")

--- a/pastisbroker/stat_manager.py
+++ b/pastisbroker/stat_manager.py
@@ -96,4 +96,4 @@ class StatManager(object):
         self._tel_file.flush()  # Flush the csv if it has not been
 
         with open(workspace.clients_stat_file, "w") as f:
-            json.dump([cli.to_dict() for cli in clients], f, indent=2)
+            json.dump([cli.to_dict() for cli in clients if cli.is_running()], f, indent=2)

--- a/pastisbroker/utils.py
+++ b/pastisbroker/utils.py
@@ -23,3 +23,22 @@ def load_engine_descriptor(py_module: str) -> Optional[FuzzingEngineDescriptor]:
             return mems[0][1]
     except ImportError:
         logging.error(f"cannot import py_module: {py_module}")
+
+
+
+COLORS = [32, 33, 34, 35, 36, 37, 39, 91, 93, 94, 95, 96]
+
+
+class Bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+def mk_color(text: str, color: str) -> str:
+    return color+text+Bcolors.ENDC

--- a/pastisbroker/workspace.py
+++ b/pastisbroker/workspace.py
@@ -31,6 +31,7 @@ class Workspace(object):
     LOG_FILE = "broker.log"
     STATUS_FILE = "STATUS"
     RUNTIME_CONFIG_FILE = "config.json"
+    COVERAGE_HISTORY = "coverage-history.csv"
 
     def __init__(self, directory: Path, erase: bool = False):
         self.root = directory
@@ -111,6 +112,10 @@ class Workspace(object):
     @property
     def config_file(self) -> Path:
         return self.root / self.RUNTIME_CONFIG_FILE
+
+    @property
+    def coverage_history(self) -> Path:
+        return self.root / self.COVERAGE_HISTORY
 
     def add_binary(self, binary_path: Path) -> Path:
         """


### PR DESCRIPTION
I added an input replay feature right in the broker to enable filtering.
Advantages:

* Can have coverage (real-time)
* Can filter input that do not generate new coverage

I also fixed, pastisdse, when it runs without explicit Config file  with a program taking input on argv.
The issue was that argv sent to the symbolic executor was basically ['@@'], when it should be ['./program', '@@'].
It now automatically preprend the binary name to argv when needed.